### PR TITLE
remove call to `block_called_from_erb?` - not used in rails 3

### DIFF
--- a/lib/abingo_view_helper.rb
+++ b/lib/abingo_view_helper.rb
@@ -16,7 +16,6 @@ module AbingoViewHelper
 
     if block
       content_tag = capture(choice, &block)
-      block_called_from_erb?(block) ? concat(content_tag) : content_tag
     else
       choice
     end


### PR DESCRIPTION
As explained in https://github.com/glenngillen/abingo/issues/2
