### PR TITLE
Updates to work with Rails 4/4.1

### DIFF
--- a/bananasplit.gemspec
+++ b/bananasplit.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = BananaSplit::VERSION
 
-  gem.add_dependency "rails", "~> 3.0"
+  gem.add_dependency "rails", "~> 4.0"
   gem.add_development_dependency "rake", "0.8.7"
 end

--- a/lib/bananasplit/alternative.rb
+++ b/lib/bananasplit/alternative.rb
@@ -12,11 +12,11 @@ class BananaSplit::Alternative < ActiveRecord::Base
   end
 
   def self.score_conversion(test_name, viewed_alternative)
-    self.update_all("conversions = conversions + 1", :lookup => self.calculate_lookup(test_name, viewed_alternative))
+    self.where(lookup: self.calculate_lookup(test_name, viewed_alternative)).update_all("conversions = conversions + 1")
   end
 
   def self.score_participation(test_name, viewed_alternative)
-    self.update_all("participants = participants + 1", :lookup => self.calculate_lookup(test_name, viewed_alternative))
+    self.where(lookup: self.calculate_lookup(test_name, viewed_alternative)).update_all("participants = participants + 1")
   end
 
 end

--- a/lib/bananasplit/experiment.rb
+++ b/lib/bananasplit/experiment.rb
@@ -40,7 +40,7 @@ class BananaSplit::Experiment < ActiveRecord::Base
   def self.exists?(test_name)
     cache_key = "BananaSplit::Experiment::exists(#{test_name})".gsub(" ", "_")
     ret = BananaSplit.cache.fetch(cache_key) do
-      count = BananaSplit::Experiment.count(:conditions => {:test_name => test_name})
+      count = BananaSplit::Experiment.where(test_name: test_name).count
       count > 0 ? count : nil
     end
     (!ret.nil?)
@@ -66,7 +66,7 @@ class BananaSplit::Experiment < ActiveRecord::Base
     conversion_name.gsub!(" ", "_")
     cloned_alternatives_array = alternatives_array.clone
     ActiveRecord::Base.transaction do
-      experiment = BananaSplit::Experiment.find_or_create_by_test_name(test_name)
+      experiment = BananaSplit::Experiment.find_or_create_by(test_name: test_name)
       experiment.alternatives.destroy_all  #Blows away alternatives for pre-existing experiments.
       while (cloned_alternatives_array.size > 0)
         alt = cloned_alternatives_array[0]


### PR DESCRIPTION
ActiveRecord::Base#update_all only takes one argument since https://github.com/rails/rails/commit/1391d74e41b786d2f1a3a4ecf7fad1eda7e49622 which it seems was merged in for Rails 4.1.1
